### PR TITLE
fix use of defines

### DIFF
--- a/src/dropbox.c
+++ b/src/dropbox.c
@@ -41,9 +41,7 @@ caja_module_initialize (GTypeModule *module) {
   caja_dropbox_register_type (module);
   type_list[0] = CAJA_TYPE_DROPBOX;
 
-  dropbox_use_caja_submenu_workaround
-    = (CAJA_VERSION_MAJOR < 2 ||
-       (CAJA_VERSION_MAJOR == 2 && CAJA_VERSION_MINOR <= 22));
+  dropbox_use_caja_submenu_workaround = FALSE;
   dropbox_use_operation_in_progress_workaround = TRUE;
 }
 


### PR DESCRIPTION
caja is at 1.5 so 2.22 and older version probably is wrong
last gnome2 was 2.32.2.1 for nautilus
