### PR TITLE
update download code from nautilus-dropbox-1.6.2

### DIFF
--- a/caja-dropbox.in
+++ b/caja-dropbox.in
@@ -430,6 +430,7 @@ if GUI_AVAILABLE:
                 self.hovering = False
                 self.clicked_link = False
                 self.user_cancelled = False
+                self.task = None
 
                 self.ok = ok = gtk.Button(stock=gtk.STOCK_OK)
                 ok.connect('clicked', self.handle_ok)


### PR DESCRIPTION
downloading and extracting `~/.dropbox-dist` is broken, this PR merges download changes from nautilus-dropbox-1.6.1.

tested with `rm -rf ~/.dropbox-dist && caja-dropbox start -i`

see discussion in #12
