### PR TITLE
setup autostart file after install

### DIFF
--- a/caja-dropbox.in
+++ b/caja-dropbox.in
@@ -1233,6 +1233,9 @@ options:
             if GUI_AVAILABLE:
                 start_dropbox()
                 console_print(u"Done!")
+
+                # downloaded dropbox doesn't create autostart file, do it ourselves
+                reroll_autostart(True)
             else:
                 if start_dropbox():
                     if not grab_link_url_if_necessary():


### PR DESCRIPTION
this is supposedly done originally by ~/.dropbox-dist/dropbox, but as it
doesn't recognize MATE, do the autostart file after download

ps: the autostart file can be done if you toggle 'do not show this
dialog' message twice in dialog which appears before download start
