### PR TITLE
Fix distcheck fail

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,12 +5,12 @@ CLEANFILES = $(bin_SCRIPTS) caja-dropbox.1 caja-dropbox.txt
 EXTRA_DIST = caja-dropbox.in serializeimages.py caja-dropbox.txt.in docgen.py rst2man.py autogen.sh
 man_MANS = caja-dropbox.1
 
-caja-dropbox: caja-dropbox.in serializeimages.py
-	python3 serializeimages.py $(PACKAGE_VERSION) $(datadir)/applications < caja-dropbox.in > caja-dropbox
+caja-dropbox: $(top_srcdir)/caja-dropbox.in $(top_srcdir)/serializeimages.py
+	python3 $(top_srcdir)/serializeimages.py $(PACKAGE_VERSION) $(datadir)/applications < $(top_srcdir)/caja-dropbox.in > caja-dropbox
 	chmod +x caja-dropbox
 
-caja-dropbox.1: caja-dropbox.txt.in caja-dropbox docgen.py
-	python3 docgen.py $(PACKAGE_VERSION) caja-dropbox.txt.in caja-dropbox.txt
+caja-dropbox.1: $(top_srcdir)/caja-dropbox.txt.in caja-dropbox $(top_srcdir)/docgen.py
+	python3 $(top_srcdir)/docgen.py $(PACKAGE_VERSION) $(top_srcdir)/caja-dropbox.txt.in caja-dropbox.txt
 	$(RST2MAN) caja-dropbox.txt > caja-dropbox.1
 
 SUBDIRS = data src

--- a/docgen.py
+++ b/docgen.py
@@ -1,4 +1,5 @@
 from __future__ import unicode_literals
+import os
 import sys
 import datetime
 import codecs
@@ -8,7 +9,9 @@ env = {"__name__":"__notmain__"}
 exec(open("caja-dropbox").read(), env)
 commands = env["commands"]
 
-with codecs.open("AUTHORS", "r", "utf-8") as afile:
+selfpath = os.path.abspath(sys.argv[0])
+top_srcdir = os.path.dirname(selfpath)
+with codecs.open(os.path.join(top_srcdir, "AUTHORS"), "r", "utf-8") as afile:
     authors = '| ' + afile.read().replace('\n', '\n| ')
 
 with codecs.open(sys.argv[2], "r", encoding="utf-8") as infile:

--- a/serializeimages.py
+++ b/serializeimages.py
@@ -1,3 +1,4 @@
+import os
 import sys
 import gi
 gi.require_version('GdkPixbuf', '2.0')
@@ -13,8 +14,10 @@ def replace_many(src2dest, buf):
     return src_re.sub(replace_repl, buf)
 
 if __name__ == '__main__':
-    pixbuf64 = GdkPixbuf.Pixbuf.new_from_file("data/icons/hicolor/64x64/apps/caja-dropbox.png")
-    pixbuf16 = GdkPixbuf.Pixbuf.new_from_file("data/icons/hicolor/16x16/apps/caja-dropbox.png")
+    selfpath = os.path.abspath(sys.argv[0])
+    top_srcdir = os.path.dirname(selfpath)
+    pixbuf64 = GdkPixbuf.Pixbuf.new_from_file(os.path.join(top_srcdir, "data/icons/hicolor/64x64/apps/caja-dropbox.png"))
+    pixbuf16 = GdkPixbuf.Pixbuf.new_from_file(os.path.join(top_srcdir, "data/icons/hicolor/16x16/apps/caja-dropbox.png"))
     src2dest = {'@PACKAGE_VERSION@': sys.argv[1],
                 '@DESKTOP_FILE_DIR@': sys.argv[2],
                 '@IMAGEDATA64@': ("GdkPixbuf.Pixbuf.new_from_data(%r, GdkPixbuf.Colorspace.RGB, %r, %r, %r, %r, %r)" %


### PR DESCRIPTION
make distcheck fail, full log here: https://travis-ci.org/mate-desktop/caja-dropbox/builds/494739402
```
make[3]: Leaving directory '/rootdir/caja-dropbox-1.21.0/_build/sub/src'
make[3]: Entering directory '/rootdir/caja-dropbox-1.21.0/_build/sub'
python3 serializeimages.py 1.21.0 /rootdir/caja-dropbox-1.21.0/_inst/share/applications < caja-dropbox.in > caja-dropbox
/bin/sh: caja-dropbox.in: No such file or directory
make[3]: *** [Makefile:944: caja-dropbox] Error 1
make[3]: Leaving directory '/rootdir/caja-dropbox-1.21.0/_build/sub'
make[2]: *** [Makefile:520: all-recursive] Error 1
make[2]: Leaving directory '/rootdir/caja-dropbox-1.21.0/_build/sub'
make[1]: *** [Makefile:374: all] Error 2
make[1]: Leaving directory '/rootdir/caja-dropbox-1.21.0/_build/sub'
make: *** [Makefile:733: distcheck] Error 1
```