### PR TITLE
fix distcheck about caja_extension_dir

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -79,14 +79,20 @@ AC_ARG_WITH(caja-extension-dir,
 AC_MSG_CHECKING([for caja extension directory])
 if test -n "$with_caja_extension_dir"; then
     CAJA_EXTENSION_DIR=$with_caja_extension_dir
+    custom_caja_extension_dir=true
 else
     CAJA_EXTENSION_DIR=`$PKG_CONFIG --variable=extensiondir libcaja-extension`
+    CAJA_EXTENSION_DIR=${CAJA_EXTENSION_DIR#`$PKG_CONFIG --variable=libdir libcaja-extension`}
+    CAJA_EXTENSION_DIR=${CAJA_EXTENSION_DIR#/}
+    custom_caja_extension_dir=false
 fi
 if test -z "$CAJA_EXTENSION_DIR"; then
-    CAJA_EXTENSION_DIR='${exec_prefix}/lib/caja/extensions-2.0'
+    CAJA_EXTENSION_DIR='caja/extensions-2.0'
+    custom_caja_extension_dir=false
 fi
 
 AC_MSG_RESULT([${CAJA_EXTENSION_DIR}])
+AM_CONDITIONAL([CUSTOM_CAJA_EXTENSION_DIR], [test x$custom_caja_extension_dir = xtrue])
 AC_SUBST(CAJA_EXTENSION_DIR)
 
 CAJA_VERSION=`$PKG_CONFIG --modversion libcaja-extension`

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -2,7 +2,11 @@ AM_CPPFLAGS =						\
 	-I$(top_srcdir)					\
 	-I$(top_builddir)
 
+if CUSTOM_CAJA_EXTENSION_DIR
 caja_extensiondir=$(CAJA_EXTENSION_DIR)
+else
+caja_extensiondir=$(libdir)/$(CAJA_EXTENSION_DIR)
+endif
 
 caja_extension_LTLIBRARIES=libcaja-dropbox.la
 


### PR DESCRIPTION
Let make distcheck pass, do something like this:
https://github.com/GNOME/evince/blob/461a306c33bd49a731152ce916114bc412e9b8fe/configure.ac#L444
