### PR TITLE
Change url project's website

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -1,6 +1,6 @@
 # Initialization
 
-AC_INIT([caja-dropbox], [1.23.0], [http://www.mate-desktop.org/])
+AC_INIT([caja-dropbox], [1.23.0], [https://mate-desktop.org/])
 
 AM_INIT_AUTOMAKE([1.9 tar-ustar dist-xz foreign no-dist-gzip])
 

--- a/data/libcaja-dropbox.caja-extension.in
+++ b/data/libcaja-dropbox.caja-extension.in
@@ -3,4 +3,4 @@ Icon=caja-dropbox
 Name=Caja Dropbox
 Description=Shows status labels in dropbox folder
 Version=@VERSION@
-Website=http://www.mate-desktop.org/
+Website=https://mate-desktop.org/


### PR DESCRIPTION
Now the official web site is https://mate-desktop.org/.