### PR TITLE
caja-dropbox: fix -Wmissing-field-initializers

### DIFF
--- a/src/caja-dropbox.c
+++ b/src/caja-dropbox.c
@@ -934,6 +934,7 @@ caja_dropbox_register_type (GTypeModule *module) {
     sizeof (CajaDropbox),
     0,
     (GInstanceInitFunc) caja_dropbox_instance_init,
+    NULL
   };
 
   static const GInterfaceInfo menu_provider_iface_info = {


### PR DESCRIPTION
```
caja-dropbox.c:937:3: warning: missing field 'value_table' initializer [-Wmissing-field-initializers]
  };
  ^
```